### PR TITLE
Add editable text and CSS breakpoint at 700px

### DIFF
--- a/script.js
+++ b/script.js
@@ -13,6 +13,10 @@ $('.save-idea-button').on('click', function(event) {
 $('.idea-list').on('click', '.delete-button', deleteIdea);
 $('.idea-list').on('click', '.upvote-button', upvote);
 $('.idea-list').on('click', '.downvote-button', downvote);
+
+$('.idea-list').on('keyup paste input', 'h2', editTitleText);
+$('.idea-list').on('keyup paste input', 'p', editBodyText);
+
 $(document).on('input', '.search-input', search);
 $(window).on('load', function() {
   loadIdeaList();
@@ -25,12 +29,45 @@ function createIdea() {
   prependIdea(ideaTitleInputValue, ideaBodyInputValue)
 }
 
+function editTitleText() {
+  var newText = $(this).text();
+  $(this).html(`<h2 contenteditable="true">${newText}</h2>`);
+  storeIdeaList();
+  setEndOfContenteditable(this);
+};
+
+function editBodyText() {
+  var newText = $(this).text();
+  $(this).html(`<p contenteditable="true">${newText}</p>`);
+  storeIdeaList();
+  setEndOfContenteditable(this);
+};
+
+function setEndOfContenteditable(contentEditableElement) {
+    var range,selection;
+    if(document.createRange) {
+        range = document.createRange();//Create a range (a range is a like the selection but invisible)
+        range.selectNodeContents(contentEditableElement);//Select the entire contents of the element with the range
+        range.collapse(false);//collapse the range to the end point. false means collapse to end rather than the start
+        selection = window.getSelection();//get the selection object (allows you to change selection)
+        selection.removeAllRanges();//remove any selections already made
+        selection.addRange(range);//make the range you have just created the visible selection
+    }
+    else if(document.selection)//IE 8 and lower
+    { 
+        range = document.body.createTextRange();//Create a range (a range is a like the selection but invisible)
+        range.moveToElementText(contentEditableElement);//Select the entire contents of the element with the range
+        range.collapse(false);//collapse the range to the end point. false means collapse to end rather than the start
+        range.select();//Select the range (make it the visible selection
+    }
+};
+
 function prependIdea(title, body) {
   $('.idea-list').prepend(`
     <div class="idea">
-      <h2>${title}</h2> 
+      <h2 contenteditable="true">${title}</h2> 
       <img class="delete-button icon" src="icons/delete.svg">
-      <p>${body}</p>
+      <p contenteditable="true">${body}</p>
       <div class="vote-container">
         <div class="vote-buttons-container">
           <img class="upvote-button icon" src="icons/upvote.svg">

--- a/styles.css
+++ b/styles.css
@@ -129,3 +129,12 @@ hr {
     margin-right: 20px;
     justify-content: space-between;
 }
+
+@media only screen and (max-width: 700px) {
+  .header-container {
+    width: 80%;
+  }
+  .ideas-container {
+    width: 80%;
+  }
+}


### PR DESCRIPTION
Text is editable in headers and body of all cards. Saves dynamically and live. One interesting interraction I had to implement was the function setEndofContenteditable, which will always move the cursor to the end of the contenteditable text. This is to counterract the default behavior of it moving back to the beginning of the editable text after every dynamic save of the text. This is avoidable if we use a button to save the new text, but I believe the awkwardness this brings is lesser than the awkwardness of a button in our UI.